### PR TITLE
Fix path to subzerocloud/pgtap image in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This docker image is available as an automated build on [the docker registry hub
 
 
 ```console
-$ docker run hbpmip/pgtap:0.96.0-5
+$ docker run subzerocloud/pgtap:pg11
 ```
 
 ## How to use this image


### PR DESCRIPTION
The path pointed to hbpmip/pgtap instead of subzerocloud/pgtap. The example now matches the link in the documentation.